### PR TITLE
Install curl in ome.basedeps

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   galaxy_tags:
     - cloud
     - system

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,10 +6,12 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: centos-c7
+  - name: centos-7
     image: centos:7
   - name: ubuntu-1804
     image: ubuntu:18.04
+  - name: ubuntu-2004
+    image: ubuntu:20.04
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -8,6 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize("package", [
+    'curl',
     'patch',
     'rsync',
     'tar',

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 basedeps_packages:
+  - curl
   - patch
   - rsync
   - tar


### PR DESCRIPTION
Fixes #8 

Recent work on the support of Ubuntu 20.04 in the Ansible example playbooks has exposed this discrepancy between operating systems since `curl` is used for the OMERO.web Molecule tests.

This PR should simply add `curl` to the list of packages installed by this role as well as the tests. It also adds Ubuntu 20.04 to the platforms tested in Molecule. 

Proposed tag: `1.2.0`