### PR TITLE
Fix the epel repo install for rhel9

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: listscenarios
         uses: ome/action-ansible-molecule-list-scenarios@main
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Ansible & Molecule
         run: |
             pip install "ansible<8" "ansible-lint<6.13" flake8

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -46,7 +46,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: galaxy
         uses: robertdebock/galaxy-action@1.2.1

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -53,4 +53,3 @@ jobs:
         with:
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
           git_branch: ${{  github.ref_name }}
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.rpm_key:
     state: present
     key:  https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+  when: ansible_os_family == 'RedHat'
 
 - name: epel | setup dnf repository
   become: true
@@ -12,6 +13,7 @@
     name:
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     state: present
+  when: ansible_os_family == 'RedHat'
 
 # use separate yum/apt tasks because package only installs one item at a time
 - name: system packages | basic system utils (rockylinux)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Import a key for epel
   ansible.builtin.rpm_key:
     state: present
-    key:  https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
   when: ansible_os_family == 'RedHat'
 
 - name: epel | setup dnf repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,17 @@
 ---
 # tasks file for roles/basedeps
-- name: system packages | install epel repo
+- name: Import a key for epel
+  ansible.builtin.rpm_key:
+    state: present
+    key:  https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+
+- name: epel | setup dnf repository
   become: true
   ansible.builtin.dnf:
-    name: epel-release
+    update_cache: true
+    name:
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     state: present
-  when: ansible_os_family == 'RedHat'
 
 # use separate yum/apt tasks because package only installs one item at a time
 - name: system packages | basic system utils (rockylinux)


### PR DESCRIPTION
This PR is fixing an error happening on RHEL 9 when the ``ome.basedeps`` role is used.


```
TASK [ome.basedeps : system packages | install epel repo] ***********************************************************************
fatal: [134.36.4.7]: FAILED! => {"changed": false, "failures": ["No package epel-release available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```

We (@khaledk2 and @pwalczysko ) opted for the solution from https://github.com/ome/ansible-role-cli-utils/blob/master/tasks/main.yml == using the key and installing epel from fedora.

This solution works on RHEL 9 - tested via playbook.