### PR TITLE
Remove all references to basedeps_install_lsb

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ Base dependencies for most servers.
 
 These dependencies should be suitable for installation on a minimal production server.
 
-
-Role Variables
---------------
-
-- `basedeps_install_lsb`: Install Linux Standard Base (LSB) packages, default `true`.
-
-
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,0 @@
----
-basedeps_install_lsb: true


### PR DESCRIPTION
Noticed with @dominikl 

This variable is a no-op since the migration to Ubuntu 22.04/RHEL9 and should not be documented